### PR TITLE
Add worldboss server support

### DIFF
--- a/DATABASE.sql
+++ b/DATABASE.sql
@@ -991,6 +991,52 @@ CREATE TABLE `work` (
   `rewards` mediumtext NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
+-- --------------------------------------------------------
+
+--
+-- Struktura tabeli dla tabeli `worldboss_event`
+--
+
+CREATE TABLE `worldboss_event` (
+  `id` int(11) NOT NULL,
+  `identifier` varchar(32) NOT NULL,
+  `npc_identifier` varchar(32) NOT NULL,
+  `stage` tinyint(1) NOT NULL DEFAULT 1,
+  `min_level` int(11) NOT NULL,
+  `max_level` int(11) NOT NULL,
+  `status` tinyint(1) NOT NULL DEFAULT 0,
+  `ts_start` int(11) NOT NULL,
+  `ts_end` int(11) NOT NULL,
+  `npc_hitpoints_total` int(11) NOT NULL,
+  `npc_hitpoints_current` int(11) NOT NULL,
+  `top_attacker_name` varchar(32) NOT NULL,
+  `top_attacker_count` int(11) NOT NULL,
+  `winning_attacker_name` varchar(32) NOT NULL,
+  `reward_top_rank_item_identifier` varchar(64) NOT NULL,
+  `reward_top_pool_item_identifier` varchar(64) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktura tabeli dla tabeli `worldboss_attack`
+--
+
+CREATE TABLE `worldboss_attack` (
+  `id` int(11) NOT NULL,
+  `character_id` int(11) NOT NULL,
+  `worldboss_event_id` int(11) NOT NULL,
+  `status` tinyint(1) NOT NULL,
+  `ts_start` int(11) NOT NULL,
+  `ts_complete` int(11) NOT NULL,
+  `duration` int(11) NOT NULL,
+  `duration_raw` int(11) NOT NULL,
+  `battle_id` int(11) NOT NULL,
+  `total_damage` int(11) NOT NULL,
+  `coin_reward` int(11) NOT NULL,
+  `xp_reward` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
 --
 -- Indeksy dla zrzutów tabel
 --
@@ -1218,6 +1264,20 @@ ALTER TABLE `work`
   ADD KEY `work` (`character_id`,`status`);
 
 --
+-- Indeksy dla tabeli `worldboss_event`
+--
+ALTER TABLE `worldboss_event`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- Indeksy dla tabeli `worldboss_attack`
+--
+ALTER TABLE `worldboss_attack`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `character_id` (`character_id`),
+  ADD KEY `worldboss_event_id` (`worldboss_event_id`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -1405,6 +1465,18 @@ ALTER TABLE `user`
 -- AUTO_INCREMENT for table `work`
 --
 ALTER TABLE `work`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_event`
+--
+ALTER TABLE `worldboss_event`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_attack`
+--
+ALTER TABLE `worldboss_attack`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 COMMIT;
 

--- a/server/class/Player.php
+++ b/server/class/Player.php
@@ -1141,4 +1141,33 @@ class Player extends Entity{
         }
         return 0;
     }
+
+    /**
+     * Pobiera aktywne wydarzenie Worldboss (bandyta) przypisane do postaci.
+     * Zwraca null jeżeli brak aktywnego wydarzenia lub jest ono zakończone.
+     */
+    public function getActiveWorldbossEvent() {
+        if (!$this->character->worldboss_event_id) {
+            return null;
+        }
+        $event = \Schema\WorldbossEvent::find(function($q) {
+            $q->where('id', $this->character->worldboss_event_id);
+        });
+        if (!$event) {
+            return null;
+        }
+        if ($event->status != 1 || time() > $event->ts_end) {
+            return null;
+        }
+        return $event;
+    }
+
+    /**
+     * Pobiera atak Worldbossa o podanym identyfikatorze należący do postaci.
+     */
+    public function getWorldbossAttackById($attackId) {
+        return \Schema\WorldbossAttack::find(function($q) use ($attackId) {
+            $q->where('id', $attackId)->where('character_id', $this->character->id);
+        });
+    }
 }

--- a/server/config.php
+++ b/server/config.php
@@ -53,6 +53,18 @@ return [
         "server"=>[
             'flash_ver'=>       'flash_129',
         ],
+        "worldboss_admin_token" => "changeme",
+        "worldboss_events" => [
+            "demo" => [
+                "npc_identifier" => "bandit_basic",
+                "min_level" => 1,
+                "max_level" => 400,
+                "duration_hours" => 24,
+                "hp" => 100000,
+                "reward_top_rank_item" => "",
+                "reward_top_pool_item" => ""
+            ]
+        ],
         "constants"=>[
             //Init
             "init_game_currency"=>1,
@@ -70,6 +82,12 @@ return [
             "init_max_free_shop_refreshes"=>1,
             "init_resource_quest_amount"=>4,
             "tutorial_finished_premium_currency"=>5,
+            "worldboss_attack_duration"=>60,
+            "worldboss_attack_instant_cost"=>1,
+            "worldboss_reward_per_attack"=>[
+                'coins'=>50,
+                'xp'=>50
+            ],
             "account_confirmed_premium_currency"=>10,
             "account_reactivated_premium_currency"=>30,
             //

--- a/server/request/assignWorldbossEvent.req.php
+++ b/server/request/assignWorldbossEvent.req.php
@@ -1,0 +1,27 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossEvent;
+
+class assignWorldbossEvent {
+    public function __request($player) {
+        $eventId = intval(getField('worldboss_event_id', FIELD_NUM));
+        $event = WorldbossEvent::find(function($q) use ($eventId) {
+            $q->where('id', $eventId);
+        });
+        if (!$event || $event->status != 1) {
+            return Core::setError('errInvalidEvent');
+        }
+
+        $player->character->worldboss_event_id = $eventId;
+        $player->character->worldboss_event_attack_count = 0;
+        $player->character->active_worldboss_attack_id = 0;
+        $player->character->current_stage = $event->stage;
+
+        Core::req()->data = [
+            'user' => $player->user,
+            'character' => $player->character
+        ];
+    }
+}

--- a/server/request/claimWorldbossEventRewards.req.php
+++ b/server/request/claimWorldbossEventRewards.req.php
@@ -1,0 +1,39 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossEvent;
+use Schema\WorldbossAttack;
+
+class claimWorldbossEventRewards {
+    public function __request($player) {
+        $eventId = intval(getField('worldboss_event_id', FIELD_NUM));
+        $discardItem = toBool(getField('discard_item', FIELD_BOOL));
+
+        if ($player->character->worldboss_event_id != $eventId) {
+            return Core::setError('errEventMismatch');
+        }
+
+        $event = WorldbossEvent::find(function($q) use ($eventId) {
+            $q->where('id', $eventId);
+        });
+        if (!$event) {
+            return Core::setError('errInvalidEvent');
+        }
+        if ($event->status == 1) {
+            return Core::setError('errEventRunning');
+        }
+
+        // Mark event as completed for the character
+        $player->character->worldboss_event_id = 0;
+        $player->character->active_worldboss_attack_id = 0;
+
+        $event->status = 4; // finished
+        $event->save();
+
+        Core::req()->data = [
+            'user' => $player->user,
+            'character' => $player->character
+        ];
+    }
+}

--- a/server/request/startWorldbossEvent.req.php
+++ b/server/request/startWorldbossEvent.req.php
@@ -34,7 +34,7 @@ class startWorldbossEvent {
         ]);
         $event->save();
         // Reset danych graczy (przypisanie do eventu)
-        \Schema\WorldbossEvent::query("UPDATE `character` SET worldboss_event_id={$event->id}, worldboss_event_attack_count=0, active_worldboss_attack_id=0");
+        \Srv\DB::sql("UPDATE `character` SET worldboss_event_id={$event->id}, worldboss_event_attack_count=0, active_worldboss_attack_id=0");
         Core::req()->data = ['worldboss_event_started' => $event->id];
     }
 } 


### PR DESCRIPTION
## Summary
- define `getActiveWorldbossEvent` and `getWorldbossAttackById` in `Player`
- define SQL tables and indexes for worldboss events/attacks
- add configuration values for worldboss events and attacks
- allow admins to start a worldboss event
- add requests for assigning worldboss events and claiming rewards

## Testing
- `php -l server/request/assignWorldbossEvent.req.php` *(fails: `php` not installed)*
- `php -l server/request/claimWorldbossEventRewards.req.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fbc375c748329b52e8725c269ec41